### PR TITLE
FEAT: add functions to create Bitcoin addresses from compressed `secp256k1` public keys

### DIFF
--- a/Clarinet.toml
+++ b/Clarinet.toml
@@ -1,7 +1,7 @@
-
 [project]
 name = "bitcoin.clar"
 
 [contracts]
+
 
 [notebooks]

--- a/Clarinet.toml
+++ b/Clarinet.toml
@@ -1,7 +1,8 @@
 [project]
 name = "bitcoin.clar"
 
-[contracts]
-
+[contracts.bitcoin]
+path = "contracts/bitcoin.clar"
+depends_on = []
 
 [notebooks]

--- a/contracts/bitcoin.clar
+++ b/contracts/bitcoin.clar
@@ -876,6 +876,7 @@
                 )                
             )
             (yCoordIsEven 
+                ;; clarity doesn't like this if, need to fix
                 (if (is-eq firstByte 0x02)
                     true
                     (if (is-eq firstByte 0x03)
@@ -886,6 +887,7 @@
             )
             ;; get yCoord from pubKey by solving y^2 = x^3 + 7
             (yCoord 
+                ;; we need to convert the buff to int before we can do the below
                 (if yCoordIsEven 
                     (sqrti (+ (pow xCoord 3) 7)) ;; returns positive y coord
                     (* (sqrti (+ (pow xCoord 3) 7)) -1) ;; returns negative y coord

--- a/contracts/bitcoin.clar
+++ b/contracts/bitcoin.clar
@@ -1,3 +1,56 @@
+;; -----------------------:+syyso+/yhsso+//::::-:::---............:oyhhhyyyys+:oyyyy/---......s+/------
+;; ------------------------:/+shysooossosooooo++/////++oosyyoo+/:...-:+shdhhyyyyyyhho---...../syhy+----
+;; ---------------------:+ossooossysoosss++/:::///:--.....-:+syyyso+/-.--/shdhhhyhhyys+/....:sossdds:--
+;; ------------------:/+o////++oooosooos/:/+oyhdhhysoss+/:-..--/oyyysso+:--:+shddhhyho++-../hysosssso++
+;; ----------------:+o/:--:/+ooo++osssys+++/::/osyhysoshhyy+:---:/+syyssss+/::/syhyyho--..ohhhssyso/::/
+;; ---::::://::::-:+:--:--/oo/::/++//shys++oo+----:+yhyooyhhy+:::++oosyys+sys+/:/shs+oo/-ohys/::/+sys+:
+;; :///:::::::/ssssooo/-:+o:--://:--/yyhhy+:/oso:----/syy++shhys++ossoosysooshhhyy+oo::+shdh+:/+//+syhs
+;; ..........-oyyyhhho://:-.--:-----s/odysyy/-:sho:---:oyys//sddhyo/oyhysyyhhhysyhs//o:-/oshdyoosso+shd
+;; .........:syyyhhs+:::...-----:--:h:ohhy+yhs:-/yh+::/+syhhs//sddhh+/ohhyyyys+//:oys/+//oo+ohdhsosyssh
+;; ........:yyyhhyo+:::-------//-://d:/hhhs+yyy///shhoooooshhhs++yhyho:/shhyys/-...:oys/:/shysshhyysssy
+;; .......:syyhs+so/-/:/:---:oo-:o:sm//yhyys+yyhoooohdssyhyo+oyhy++ysso-/syysdho-../-/sho//+yhdyyhhdho+
+;; /:-.``-syydh/ys/:o++/--::oy::s+:yms+oyyyss+yhhsoo+yd+/syhhys+oyhsyo:+-syysoshyo/:+:ssys/:/ohhdyhhdyo
+;; syhyo/oyyhd/oyo:o+y+::/+sd/:os++hmhoooyhy+s+yddo/:-sh--shyyydhs+sdd//sydmys+/+oshhhhys+o/::+yhdhymms
+;; -oyyyhhyhdo/hs/++hy++ooydh//hhoodhd+:-:sdh/::ods--..os.:yyyhhhddoody+hsddy+oydhhdhyo/yy/::::/yhdhymy
+;; --+yhhhhdh:oho:s+hsoooohmh++dh++dyyy--.-/hd+-/sd/---/y+/shyydddddyyh/shhss+:+yds++::::yh/:::::shdhhh
+;; ---/shhhd/-hy-:sohsoooodms:ody-:hhshy:---/ydy/osyo/+odo:/dhyhhdmddyhshd+/oyhyoyh/-+:--:sh:-:++:shdyh
+;; ..--:yydy:/d/--s/hyo+/+dm+-+dh--smyddho:-:::oyho/+osyyy+:/hysydmddhhhdy/:::/syydy:/+:--:hy:-/so/ydh+
+;; ...-+yhd/:oy-.-s/oy+:::hd/:odd:-+mdhdhdhsos/://+syhhy+ys//+yysdmyhdy+syyo+///+/+dy:so---om+-+oys+hho
+;; ..../sys:/so...oh/ys+::ydy//hmso/hmhdyydmddyo+/::////++o///+yyhdsdddyo///+oyds++hmsoh:--:dy-/yosyhhy
+;; .....-y/:+s/---osy+:/+shdy::omd++ommho+sddhhhdhyssoo+oossoooyhhmhydmmmddddyyhdddhhdsd+---sd::yy+sddy
+;; o/:-./s:sos:---ssohyo++shdo++smo//yddho/+ydhhhyyhhhddhmmmho/:+yhdddddhyso/::/++++sdddo---om+-shs:shy
+;; -/+hsysssos::--+s/oyhhyo/sho//oy///hdhds/:/yhhy++yy+s++hhhyso//+ooyy/-....-:..-+o-ymmo-:-omo:yhhy+sh
+;; -:+hohsdyoy/s///h///sh+///yy/::+s/:+yhsss/::+yhy//hs/yo+yhs/ssyy+o+/:.+/-:yy:ohmo/yNh:/--sd+/hhsyhoy
+;; -:yoodhdhoyso+:+yo/::yy/::+hh+::os:o++hho+o/-:hds-yd/shsossy+o+-....-omdhdmmhsdmddhd/o/--hd:shy::ydy
+;; -+s+sdhdhyhds+:+yy/://hy/:/ydmo::hy:yo+ddysh/-/mh:smoyy-.../+:..-++syoo/:.--.----:ysds--/dhyhy:-+yhd
+;; :soyhmdmhyhmdo+:yy+:::/hy::/hdm/-smohdoydd/yd//hmoymho-.......:oyyo-.............oshd:--ymdhsy/:syhm
+;; :hsdhmhmhhdhmho//yy+:::/do:-ommy/dm+ddhhyhhyhhohdy+/:.........-//...............+syds--odhs::oy+hyhd
+;; +hhhsmhmhhmosddo::+ys/::sd:-/dNmhmNmmmmhysds+++:-..............................-y/hms:oyo/:-::shhhdo
+;; syyy+dhdhhm+:/ody/::/s:-/ds+yNNNmmhsomhhhmNNmdy/:..............................:y/ymd+/:::::::/yhds/
+;; yyoy/hmydhm+::+dy:o/:/ho:hhsmNNh+///ymhodmhhdhys+-.............................-y/smmo:::::::/+/yhyy
+;; hy+y+hmhydm+::+dy:/yo:odyhmmmho///:/hds++ss+s+oyo..----.........................os/mmd+/::/:::os+sdh
+;; hs/sohdmydm++:/dy:-/d+/hmhmmdo///::::://:::---+s+..:--/:........................:doohmms::o+:/:sdssy
+;; hs+osdddddmos::hh:--dsydNddhs:::::--.oy/-.-:+/:-....:://.........................+dyhdm+/:+h+/o/ymhs
+;; yoo/yhmdhdmys:-om/-+dhhhmddy/----...../soo+:........:/-..........................-hyhmy/+//sh++ysydh
+;; soo+ysmdddmhh:-:dy:ss+:-+yhdho-.-..../ss/...........-//:.............--...-...-.-syohmh+os+/hhsoshdd
+;; +y/oshdddmmhd+--+doso-----/+osy+//+++o/--...........................:+-...---/--+yohmdmdoyyoohdhysss
+;; -+soshddhmmdds---/hyds:---:o/-:+++//---....................--:/++oo+o-.-------::y/sddhhmhsdh+/sdddhh
+;; -:/syyddhdhhdd:----+yhho:--:ss/-/ossyo:................:+syyhhyhhs-...--------:oshddodhmmyhddo::+syh
+;; ---:ohdddd+dddy:-----/yhhs/--sho--odsshs-...........//+h+syyyyhh+.....:hh:-::/s/.::-/dmmmhhddddhyyyh
+;; -----/hNmyhdmddh::/---:shhhhhssho--/dyohy:.............+hyyhhy+-.....-hms---/s/.....+mNmhyymdhyhhyyo
+;; ------:+dssshmdddooyo:-:/shyyhhdd+--/dyshy-.............:+++:.......-shm/-.:so-..../hyyyhyydhh+sds:.
+;; -------/h:oyhddhdddhhds:--:+o+/smd/--ohyhh/.........................+ydmo--ss:....:dhyhhyhdhhdds:-..
+;; ------:osohdhsdhooyddddh/---:ss/sms:::syhh+........................-yodyohyo:....-yhyyyyhhyyhy/-....
+;; ---://shshydo:hd+-/ydyshd+/--:ohohd::::/hhs+:-..--:+-............../yys/sy/-....-ohyyyo//oyh+-.....-
+;; ---::///oyhdo:+hh/::+yyhmdy::-:shhh::o::hddhhysssydh:---..........-y:--ss-......+yyyo///os+-.....-::
+;; --------oyyoosoosyys/::ymdd//+:oddy::so:shh+++oyhdmdhyso+//:---.../s..+y-.....-/yyy+//os+-......:/:-
+;; ---/oo/-/yoo-:/+/ohhhysdddy:yy:+dddo:/yo+hhyhdNmddysmmdhhhhyyso/::s:.-oy-.....:syy+/+o+-......-oho..
+;; --:+sss+:+yh/-----+symmmdmo/hh::shdds/+hsshdyyhdmNNdmNNmhyyyyyhhyyo-../h:.....:yy+/++-......-+hms-..
+;; -/sssssso/:/o+:---/hshmydddoyNy//+yhhhsshddmNNNNNNNMNMNmsyhyhhyhds-.../h/....-/sy+:-......./hNmo-...
+;; -:+osssssso+//:--:osodddydmmhmNNhyssyydNmmNMMMMNNNNNMNNNh/shdmmmd:...-/h/...:o/:-........:smNdo-....
+;; ----:://///+/::+shysohyydmNMMNMMMMMMMMMMNNNNNNNNNNNNNmhm/+:oddNNy....-sd/..-+-.........:yNMNd/-....-
+;; --------------:/++/--:osmNNNMMMMMMMMMMNNNNNNNNNNNNNNmNdNmho-odmNy.....:y-.-:.........-omMMNy:.....:y
+
 ;; Error codes
 (define-constant ERR-OUT-OF-BOUNDS u1)
 (define-constant ERR-TOO-MANY-TXINS u2)
@@ -782,4 +835,77 @@
         (verify-merkle-proof (get-reversed-txid tx) (get merkle-root block) proof)
         (err u1)
     )
+)
+
+;; ========================================================================================
+
+;; PUB2BTC
+
+;; this contract can identify:
+;;  1. P2PKH (legacy, start with '1')
+;;  2. P2SH (start with '3')
+;;  3. P2WPKH, AKA Bech32 (start with 'bc1')
+;; Base58Check encoding is used for encoding byte arrays in Bitcoin 
+;; into human-typable strings. this processes using Base58Check
+
+(define-read-only (verify-bitcoin-address 
+        (signature (buff 65))
+        (btcAddress (buff 100))
+        (hash (buff 32))
+    )
+    (begin
+        (if () () ())
+    )
+)
+
+(define-read-only (get-bitcoin-address-type (address (buff 100)))
+    (if ((is-eq (element-at address u0) 0x00)) ;; P2PKH
+        (ok 'p2pkh') 
+        (if ((is-eq (element-at address u0) 0x02)) expr-if-true expr-if-false))
+)
+
+;; PRIVATE FUNCTIONS
+
+(define-private (get-p2pkh (pubKey (buff 33)))
+    (let 
+        (
+            (firstByte (unwrap! (element-at pubKey u0) (err u0)))
+            (xCoord 
+                (   
+                    ;; TODO            
+                )                
+            )
+            (yCoordIsEven 
+                (if (is-eq firstByte 0x02)
+                    true
+                    (if (is-eq firstByte 0x03)
+                        false
+                        (err u0) ;; first byte is not either even or false
+                    )
+                )
+            )
+            ;; get yCoord from pubKey by solving y^2 = x^3 + 7
+            (yCoord 
+                (if yCoordIsEven 
+                    (sqrti (+ (pow xCoord 3) 7)) ;; returns positive y coord
+                    (* (sqrti (+ (pow xCoord 3) 7)) -1) ;; returns negative y coord
+                )
+            )
+            (decompressedPubKey
+                (concat 0x04 xCoord yCoord)
+            )
+        )
+        ;; make sure decompressedPubKey is 65 bytes
+        (asserts! (is-eq (len decompressedPubKey) u65) (err u0))
+        ;; return hexadecimal P2PKH address
+        (ok (hash160 decompressedPubKey))
+    )
+)
+
+(define-private (get-p2sh (pubKey (buff 33)))
+
+)
+
+(define-private (get-p2wpkh (pubKey (buff 33)))
+
 )


### PR DESCRIPTION
Resolves #1 

---

This adds some read-only functions to create the following Bitcoin address types from compressed `secp256k1` public keys.

- [ ] P2PKH (legacy, start with '1')
- [ ] P2SH (start with '3')
- [ ] P2WPKH, AKA Bech32 (start with 'bc1')

